### PR TITLE
Gestion de l'id OpinionWay

### DIFF
--- a/src/app/(layout-with-navigation)/(simulation)/fin/page.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/fin/page.tsx
@@ -10,8 +10,8 @@ export default function FinPage() {
     let value = null
     if (localStorageValue) {
       const JSONValue = JSON.parse(localStorageValue)
-      //TODO: Pour l'instant on prend la première mais à voir pour la suite
-      JSONValue.simulation = JSONValue.simulations[0]
+      //TODO: Pour l'instant on prend la dernière mais à voir pour la suite
+      JSONValue.simulation = JSONValue.simulations.at(-1)
       delete JSONValue.simulations
       value = JSON.stringify(JSONValue)
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Homepage() {
     setOpinionWayId(opinionWayId);
 
     const storedData = localStorage.getItem('nosgestesempreinte::v1');
-    if (storedData) {
+    if (storedData && opinionWayId) {
       const parsedData = JSON.parse(storedData);
       const opinionWayIdExists = parsedData.simulations.some(simulation => simulation.opinionWayId === opinionWayId);
       if (!opinionWayIdExists) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,13 +2,15 @@
 
 import Main from '@/design-system/layout/Main'
 import Buttons from "@/app/_components/heading/Buttons";
-import { useEffect } from 'react';
+import {useEffect, useState} from 'react';
 
 
-export default async function Homepage() {
+export default function Homepage() {
+  const [opinionWayId, setOpinionWayId] = useState<string | null>(null);
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const opinionWayId = urlParams.get('opinion-way-id');
+    setOpinionWayId(opinionWayId);
 
     const storedData = localStorage.getItem('nosgestesempreinte::v1');
     if (storedData) {
@@ -27,7 +29,7 @@ export default async function Homepage() {
             <h1 className="md:text-5xl">
               {'Bonjour, vous allez répondre à des questions sur votre empreinte carbone'}
             </h1>
-            <Buttons/>
+            {opinionWayId && <Buttons/>}
           </div>
         </div>
       </Main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,24 @@
-import Main from '@/design-system/layout/Main'
-import { getMetadataObject } from '@/helpers/metadata/getMetadataObject'
-import Buttons from "@/app/_components/heading/Buttons";
+'use client';
 
-export async function generateMetadata() {
-  return getMetadataObject({
-    title:
-      "Votre calculateur d'empreinte carbone personnelle - Nos Gestes Climat"
-    ,
-    description:
-      'Connaissez-vous votre empreinte sur le climat ? Faites le test et découvrez comment réduire votre empreinte carbone sur le climat.'
-    ,
-    alternates: {
-      canonical: '/',
-    },
-  })
-}
+import Main from '@/design-system/layout/Main'
+import Buttons from "@/app/_components/heading/Buttons";
+import { useEffect } from 'react';
+
 
 export default async function Homepage() {
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const opinionWayId = urlParams.get('opinion-way-id');
+
+    const storedData = localStorage.getItem('nosgestesempreinte::v1');
+    if (storedData) {
+      const parsedData = JSON.parse(storedData);
+      const opinionWayIdExists = parsedData.simulations.some(simulation => simulation.opinionWayId === opinionWayId);
+      if (!opinionWayIdExists) {
+        localStorage.clear();
+      }
+    }
+  }, []);
   return (
     <>
       <Main>

--- a/src/helpers/simulation/generateSimulation.ts
+++ b/src/helpers/simulation/generateSimulation.ts
@@ -16,6 +16,7 @@ export function generateSimulation({
   groups,
   savedViaEmail,
   migrationInstructions,
+  opinionWayId,
 }: Partial<Simulation> & {
   migrationInstructions?: MigrationType
 } = {}): Simulation {
@@ -32,6 +33,7 @@ export function generateSimulation({
     polls,
     groups,
     savedViaEmail,
+    opinionWayId,
   } as Simulation
 
   if (migrationInstructions) {

--- a/src/hooks/navigation/useSimulateurPage.ts
+++ b/src/hooks/navigation/useSimulateurPage.ts
@@ -15,6 +15,7 @@ type GoToSimulateurPageProps = {
     defaultAdditionalQuestionsAnswers?: Record<string, string>
     poll?: string
     group?: string
+    opinionWayId: string
   }
 }
 const goToSimulateurPagePropsDefault = {

--- a/src/pages/api/add-row.ts
+++ b/src/pages/api/add-row.ts
@@ -33,7 +33,7 @@ export default async function handler(
     }
 
     const jsonData = JSON.parse(data);
-    const userId = jsonData.user?.userId;
+    const userId = jsonData.simulation?.opinionWayId;
     const spreadsheetId = process.env.SPREADSHEET_ID;
 
     if (!userId || !uuidValidate(userId)) {
@@ -61,8 +61,6 @@ export default async function handler(
     });
 
     const service = google.sheets({ version: 'v4', auth });
-
-    console.log(jsonData)
 
     const values = [mapDataToSheet(jsonData.simulation, keys)];
     values[0].unshift(userId); // Insert userId at the beginning

--- a/src/publicodes-state/hooks/useUser/useSimulations.ts
+++ b/src/publicodes-state/hooks/useUser/useSimulations.ts
@@ -63,6 +63,12 @@ export default function useSimulations({
           migrationInstructions,
         })
 
+        const urlParams = new URLSearchParams(window.location.search);
+        const opinionWayId = urlParams.get('opinion-way-id');
+        if (opinionWayId) {
+          migratedSimulation.opinionWayId = opinionWayId;
+        }
+
         newCurrentId = migratedSimulation.id
 
         return [...prevSimulations, migratedSimulation]

--- a/src/publicodes-state/providers/userProvider/usePersistentSimulations.ts
+++ b/src/publicodes-state/providers/userProvider/usePersistentSimulations.ts
@@ -31,6 +31,11 @@ export default function usePersistentSimulations({ storageKey }: Props) {
       setCurrentSimulationId(localCurrentSimulationId)
     } else {
       const newSimulation = generateSimulation()
+      const urlParams = new URLSearchParams(window.location.search);
+      const opinionWayId = urlParams.get('opinion-way-id');
+      if (opinionWayId) {
+        newSimulation.opinionWayId = opinionWayId;
+      }
       setSimulations([newSimulation])
       setCurrentSimulationId(newSimulation.id)
     }

--- a/src/publicodes-state/providers/userProvider/useUpdateOldLocalStorage.ts
+++ b/src/publicodes-state/providers/userProvider/useUpdateOldLocalStorage.ts
@@ -17,18 +17,20 @@ function handleLocalStorageMigration(
   migrationInstructions: MigrationType
 ) {
   try {
-    const newSimulations = currentLocalStorage.simulations.map(
-      (simulation: Simulation) =>
-        migrateSimulation({
-          simulation,
-          migrationInstructions,
-        })
-    )
+    if(currentLocalStorage.simulations) {
+      const newSimulations = currentLocalStorage.simulations.map(
+          (simulation: Simulation) =>
+              migrateSimulation({
+                simulation,
+                migrationInstructions,
+              })
+      )
 
-    localStorage.setItem(
-      storageKey,
-      JSON.stringify({ ...currentLocalStorage, simulations: newSimulations })
-    )
+      localStorage.setItem(
+          storageKey,
+          JSON.stringify({ ...currentLocalStorage, simulations: newSimulations })
+      )
+    }
   } catch (error) {
     console.warn('Error trying to migrate LocalStorage:', error)
   }

--- a/src/publicodes-state/types.d.ts
+++ b/src/publicodes-state/types.d.ts
@@ -71,6 +71,7 @@ export type Simulation = {
   polls?: string[] | null
   groups?: string[] | null
   savedViaEmail?: boolean
+  opinionWayId: string
 }
 
 type UpdateCurrentSimulationProps = {


### PR DESCRIPTION

:triangular_flag_on_post: Objectifs
----
- Récupérer l'ID d'OpinionWay pour le gérer en fonction des sondés
- Transmettre cet ID dans le Google Sheet

:watermelon: Implémentation
----
- Regarder l'implémentation de la page d'accueil dans laquelle on clear le local storage lorsque l'id OW n'est pas connu des simulations présentes dans ce local storage
- Ajout d'un attribut opinionWayId et ajout lors de la génération de la simulation

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)