### PR TITLE
Feature/44 les intitulés saffichent en double

### DIFF
--- a/src/components/form/question/mosaic/mosaicQuestion/MosaicBooleanInput.tsx
+++ b/src/components/form/question/mosaic/mosaicQuestion/MosaicBooleanInput.tsx
@@ -76,29 +76,24 @@ export default function MosaicBooleanInput({
       </span>
 
       <div className="flex-1">
-        {title && !icons ? (
+        {title && (
           <span
             className={`inline align-middle text-sm font-medium md:text-xl ${labelClassNames[status]}`}>
             <Emoji className="inline-flex">{title}</Emoji>{' '}
+            {icons && <Emoji className="inline-flex items-center">{icons}</Emoji>}
           </span>
-        ) : null}
-        {title && icons ? (
-          <span
-            className={`inline align-middle text-sm font-medium md:text-xl ${labelClassNames[status]}`}>
-            <Emoji className="inline-flex">{title}</Emoji>{' '}
-            <Emoji className="inline-flex items-center">{icons}</Emoji>
-          </span>
-        ) : null}
-        {description ? (
+        )}
+        {description && (
           <p className="mb-0 text-xs italic md:text-sm">
             {description.split('\n')[0]}
           </p>
-        ) : null}
+        )}
       </div>
       {isInactive ? (
-        <div className="absolute bottom-1 right-4 top-1 flex -rotate-12 items-center justify-center rounded-xl border-2 border-black bg-white p-2 text-xs font-semibold text-black">
-          <Trans>Bientôt disponible</Trans>
-        </div>
+          <div
+              className="absolute bottom-1 right-4 top-1 flex -rotate-12 items-center justify-center rounded-xl border-2 border-black bg-white p-2 text-xs font-semibold text-black">
+            <Trans>Bientôt disponible</Trans>
+          </div>
       ) : null}
     </label>
   )

--- a/src/components/form/question/mosaic/mosaicQuestion/MosaicBooleanInput.tsx
+++ b/src/components/form/question/mosaic/mosaicQuestion/MosaicBooleanInput.tsx
@@ -76,7 +76,7 @@ export default function MosaicBooleanInput({
       </span>
 
       <div className="flex-1">
-        {title ? (
+        {title && !icons ? (
           <span
             className={`inline align-middle text-sm font-medium md:text-xl ${labelClassNames[status]}`}>
             <Emoji className="inline-flex">{title}</Emoji>{' '}


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

- Trouver et corriger le code qui doublonnait les intitulés des questions mosaiques

:watermelon: Implémentation
----

- Changement de la condition
- Factorisation du code

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)
