### PR TITLE
39 - changement des actions de la page d'accueil

### DIFF
--- a/src/app/_components/heading/Buttons.tsx
+++ b/src/app/_components/heading/Buttons.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Link from '@/components/Link'
 import Trans from '@/components/translation/Trans'
 import ButtonLink from '@/design-system/inputs/ButtonLink'
 import { useSimulateurPage } from '@/hooks/navigation/useSimulateurPage'
@@ -15,7 +14,6 @@ export default function Buttons() {
   const isClient = useIsClient()
 
   const {
-    goToSimulateurPage,
     getLinkToSimulateurPage,
     linkToSimulateurPageLabel,
   } = useSimulateurPage()
@@ -32,14 +30,9 @@ export default function Buttons() {
         onMouseEnter={() => setIsHover(true)}
         onMouseLeave={() => setIsHover(false)}
         onClick={() => {
-          if (progression === 1) {
-            return
-          }
-
           if (progression > 0) {
             return
           }
-
         }}>
         <span
           className={twMerge(
@@ -51,19 +44,6 @@ export default function Buttons() {
           <Trans>{linkToSimulateurPageLabel}</Trans>
         </span>
       </ButtonLink>
-
-      {progression ? (
-        <Link
-          className={`absolute left-1/2 top-full -translate-x-1/2 translate-y-6 whitespace-nowrap transition-all delay-200 duration-300 md:text-lg ${
-            isClient ? 'opacity-100' : 'opacity-0'
-          }`}
-          onClick={() => {
-            goToSimulateurPage({ noNavigation: true, newSimulation: {} })
-          }}
-          href={getLinkToSimulateurPage({ newSimulation: true })}>
-          <Trans>Commencer un nouveau test</Trans>
-        </Link>
-      ) : null}
     </div>
   )
 }

--- a/src/app/homePage.tsx
+++ b/src/app/homePage.tsx
@@ -3,8 +3,11 @@
 import Main from '@/design-system/layout/Main'
 import Buttons from "@/app/_components/heading/Buttons";
 import {useEffect, useState} from 'react';
+import { useCurrentSimulation } from '@/publicodes-state';
 
 export default function Homepage() {
+  const { progression } = useCurrentSimulation()
+
   const [opinionWayId, setOpinionWayId] = useState<string | null>(null);
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
@@ -26,12 +29,16 @@ export default function Homepage() {
         <div className="relative flex items-center justify-center overflow-hidden p-4 h-[100vh]">
           <div className="relative mb-2 text-center md:mb-0">
             <h1 className="md:text-5xl">
-              Bonjour, vous allez répondre à des questions sur votre empreinte carbone
+              {
+                progression < 1
+                  ? 'Bonjour, vous allez répondre à des questions sur votre empreinte carbone'
+                  : 'Bonjour, vous avez déjà répondu à l\'enquête, merci'
+              }
             </h1>
-            {opinionWayId && <Buttons/>}
-'          </div>
-'        </div>
+            {opinionWayId && progression != 1 && <Buttons/>}
+          </div>
+        </div>
       </Main>
     </>
-)
+  )
 }

--- a/src/hooks/navigation/useSimulateurPage.ts
+++ b/src/hooks/navigation/useSimulateurPage.ts
@@ -1,27 +1,9 @@
 import { getLinkToSimulateur } from '@/helpers/navigation/simulateurPages'
-import { useCurrentSimulation, useUser } from '@/publicodes-state'
-import { Situation } from '@/publicodes-state/types'
-import { useRouter } from 'next/navigation'
+import { useCurrentSimulation } from '@/publicodes-state'
 import { useCallback, useMemo } from 'react'
 import { useClientTranslation } from '../useClientTranslation'
 import { useEndPage } from './useEndPage'
 
-type GoToSimulateurPageProps = {
-  noNavigation?: boolean
-  newSimulation?: {
-    situation?: Situation
-    persona?: string
-    foldedSteps?: string[]
-    defaultAdditionalQuestionsAnswers?: Record<string, string>
-    poll?: string
-    group?: string
-    opinionWayId: string
-  }
-}
-const goToSimulateurPagePropsDefault = {
-  noNavigation: false,
-  newSimulation: undefined,
-}
 type GetLinkToSimulateurPageProps = {
   newSimulation?: boolean
 }
@@ -29,41 +11,11 @@ const getLinkToSimulateurPagePropsDefault = {
   newSimulation: false,
 }
 export function useSimulateurPage() {
-  const router = useRouter()
-
   const { t } = useClientTranslation()
 
-  const { initSimulation } = useUser()
-
-  const { goToEndPage, getLinkToEndPage } = useEndPage()
+  const { getLinkToEndPage } = useEndPage()
 
   const { progression } = useCurrentSimulation()
-
-  const goToSimulateurPage = useCallback(
-    async ({
-      noNavigation = false,
-      newSimulation = undefined,
-    }: GoToSimulateurPageProps = goToSimulateurPagePropsDefault) => {
-      // If there is no current simulation (or we want to force a new one), we init a new simulation
-      if (newSimulation) {
-        initSimulation(newSimulation)
-      }
-
-      // If we don't want to navigate, we do nothing
-      if (noNavigation) {
-        return
-      }
-
-      // If the user has completed the test we redirect him to the results page
-      if (progression === 1 && !newSimulation) {
-        goToEndPage()
-        return
-      }
-
-      router.replace(getLinkToSimulateur())
-    },
-    [router, initSimulation, progression, goToEndPage]
-  )
 
   const getLinkToSimulateurPage = useCallback(
     ({
@@ -80,19 +32,14 @@ export function useSimulateurPage() {
   )
 
   const linkToSimulateurPageLabel = useMemo(() => {
-    // If the user has completed the test we return the results page label
-    if (progression === 1) {
-      return t('Voir les résultats')
-    }
     if (progression > 0) {
-      return t('Reprendre mon test')
+      return t('Reprendre l\'enquête')
     }
     
-    return t('Commencer le test →');
+    return t('Commencer l\'enquête');
   }, [progression, t])
 
   return {
-    goToSimulateurPage,
     getLinkToSimulateurPage,
     linkToSimulateurPageLabel,
   }


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs

Modifier la page d'accueil pour prendre en compte les cas suivants : 
- La personne n'a jamais commencé le sondage : elle a un message d'accueil + un bouton qui lui propose de commencer l'enquête 
- La personne a commencé mais pas fini le sondage : elle a un message d'accueil + un bouton qui lui propose de continuer l'enquête 
- La personne a fini le sondage : elle a un message lui indiquant qu'elle a déjà répondu à l'enquête
----

:watermelon: Implémentation

Suppression de code inutile + ajout de condition sur la page d'accueil
----

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)
