### PR TITLE
feat: Ordering questions by order key in publicodes

### DIFF
--- a/src/publicodes-state/providers/formProvider/useQuestions.ts
+++ b/src/publicodes-state/providers/formProvider/useQuestions.ts
@@ -145,19 +145,41 @@ export default function useQuestions({
     ]
   )
 
-  const questionsWithOrder: { key: string, ordre: number }[] = [];
+  // Regrouper les questions par catégorie (le premier mot avant le premier point)
+  const questionsByCategory: { [category: string]: { key: string, ordre: number }[] } = {};
 
+  // Parcourir toutes les questions
   remainingQuestions.forEach((key) => {
     const rule = safeGetRule(key);
-    // On récupère l'ordre ou on utilise Infinity pour les éléments sans ordre
-    const ordre = rule?.rawNode?.ordre !== undefined ? rule?.rawNode?.ordre : Infinity;
-    questionsWithOrder.push({ key, ordre });
+    const ordre = rule?.rawNode?.ordre !== undefined ? rule.rawNode.ordre : Infinity;
+
+    // Extraire la catégorie (le premier mot avant le premier point)
+    const category = key.split(' . ')[0];
+
+    // Si la catégorie n'existe pas encore, la créer
+    if (!questionsByCategory[category]) {
+      questionsByCategory[category] = [];
+    }
+
+    // Ajouter la question dans la catégorie correspondante
+    questionsByCategory[category].push({ key, ordre });
   });
 
-  // Trier par ordre croissant
-  questionsWithOrder.sort((a, b) => a.ordre - b.ordre);
+  // Créer un tableau pour stocker le résultat final trié
+  const sortedKeys: string[] = [];
 
-  const sortedKeys = questionsWithOrder.map(item => item.key);
+  // Parcourir les catégories et trier les questions dans chaque catégorie par ordre
+  Object.keys(questionsByCategory).forEach((category) => {
+    const questions = questionsByCategory[category];
+
+    // Trier les questions dans chaque catégorie par ordre
+    questions.sort((a, b) => a.ordre - b.ordre);
+
+    // Ajouter les clés triées dans le tableau final
+    questions.forEach((item) => {
+      sortedKeys.push(item.key);
+    });
+  });
 
   remainingQuestions = sortedKeys
 

--- a/src/publicodes-state/providers/formProvider/useQuestions.ts
+++ b/src/publicodes-state/providers/formProvider/useQuestions.ts
@@ -28,6 +28,7 @@ type Props = {
 export default function useQuestions({
   root,
   safeEvaluate,
+  safeGetRule,
   categories,
   subcategories,
   situation,
@@ -47,7 +48,7 @@ export default function useQuestions({
     [safeEvaluate, root, everyQuestions, situation]
   )
 
-  const remainingQuestions = useMemo<string[]>(
+  let remainingQuestions = useMemo<string[]>(
     () =>
       // We take every questions
       everyQuestions
@@ -143,6 +144,22 @@ export default function useQuestions({
       everyMosaicChildren,
     ]
   )
+
+  const questionsWithOrder: { key: string, ordre: number }[] = [];
+
+  remainingQuestions.forEach((key) => {
+    const rule = safeGetRule(key);
+    // On récupère l'ordre ou on utilise Infinity pour les éléments sans ordre
+    const ordre = rule?.rawNode?.ordre !== undefined ? rule?.rawNode?.ordre : Infinity;
+    questionsWithOrder.push({ key, ordre });
+  });
+
+  // Trier par ordre croissant
+  questionsWithOrder.sort((a, b) => a.ordre - b.ordre);
+
+  const sortedKeys = questionsWithOrder.map(item => item.key);
+
+  remainingQuestions = sortedKeys
 
   const relevantAnsweredQuestions = useMemo<string[]>(
     () =>


### PR DESCRIPTION

:triangular_flag_on_post: Objectifs
----
- Gérer l'ordre des questions dans le front en définissant un ordre dans le modèlé

:watermelon: Implémentation
----
- Dans le **useQuesitons.ts** au moment où on définit le les questions restantes, on prend la liste de ces questions, on regarde s'il y a un attribut "ordre" dans la règle et on trie par cet attribut. 

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)