### PR TITLE
fix journeys input in mobile

### DIFF
--- a/src/components/questions/voiture/journeysInput/journeysInputMobile/AddJourneyMobile.tsx
+++ b/src/components/questions/voiture/journeysInput/journeysInputMobile/AddJourneyMobile.tsx
@@ -47,7 +47,7 @@ export default function AddJourneyMobile({ setJourneys, className }: Props) {
       <td className="block border-primary-700 pb-4 text-sm ">
         <span className="flex items-end gap-4">
           <TextInputGroup
-            className="w-12 text-sm md:w-16"
+            className="text-sm md:w-16"
             name="distance"
             type="number"
             label={t('Distance')}


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs

Fix le design sur mobile de l'ajout du nombre de kilomètre sur les trajets en voiture
----

:watermelon: Implémentation
J'ai enlevé la définition de la taille de cet input, qui prend donc toute la largeur de la apge
----

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)
