### PR TITLE
Rendre obligatoire le détail des trajets pour les km en voiture

### DIFF
--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -61,71 +61,73 @@ export default function Question({ question, tempValue, setTempValue, showInput 
         <Label question={question} label={label} description={description} />
 
         {showInput && (
-          <Suggestions
-            question={question}
-            setValue={(value) => {
-              if (type === 'number') {
-                if (setTempValue) setTempValue(value)
-              }
-              setValue(value, { foldedStep: question })
-            }}
-          />
-        )}
-
-        {type === 'number' && showInput && (
-          <NumberInput
-            unit={unit}
-            value={setTempValue ? tempValue : numericValue}
-            setValue={(value) => {
-              if (setTempValue) {
-                setTempValue(value)
-              }
-              setValue(value, { foldedStep: question })
-            }}
-            isMissing={isMissing}
-            min={0}
-            id={DEFAULT_FOCUS_ELEMENT_ID}
-            aria-describedby={QUESTION_DESCRIPTION_BUTTON_ID}
-          />
-        )}
-
-        {type === 'boolean' && showInput && (
-          <BooleanInput
-            value={value}
-            setValue={(value) => {
-              {
+          <>
+            <Suggestions
+              question={question}
+              setValue={(value) => {
+                if (type === 'number') {
+                  if (setTempValue) setTempValue(value)
+                }
                 setValue(value, { foldedStep: question })
-              }
-            }}
-            isMissing={isMissing}
-            label={label || ''}
-            id={DEFAULT_FOCUS_ELEMENT_ID}
-            aria-describedby={QUESTION_DESCRIPTION_BUTTON_ID}
-          />
-        )}
+              }}
+            />
 
-        {type === 'choices' && showInput && (
-          <ChoicesInput
-            question={question}
-            choices={choices}
-            value={String(value)}
-            setValue={(value) => {
-              {
-                setValue(value, { foldedStep: question })
-              }
-            }}
-            isMissing={isMissing}
-            label={label || ''}
-            id={DEFAULT_FOCUS_ELEMENT_ID}
-            aria-describedby={QUESTION_DESCRIPTION_BUTTON_ID}
-          />
-        )}
+            {type === 'number' && (
+              <NumberInput
+                unit={unit}
+                value={setTempValue ? tempValue : numericValue}
+                setValue={(value) => {
+                  if (setTempValue) {
+                    setTempValue(value)
+                  }
+                  setValue(value, { foldedStep: question })
+                }}
+                isMissing={isMissing}
+                min={0}
+                id={DEFAULT_FOCUS_ELEMENT_ID}
+                aria-describedby={QUESTION_DESCRIPTION_BUTTON_ID}
+              />
+            )}
 
-        {type === 'mosaic' && showInput && (
-          <Mosaic
-            question={question}
-            aria-describedby={QUESTION_DESCRIPTION_BUTTON_ID}
-          />
+            {type === 'boolean' && (
+              <BooleanInput
+                value={value}
+                setValue={(value) => {
+                  {
+                    setValue(value, { foldedStep: question })
+                  }
+                }}
+                isMissing={isMissing}
+                label={label || ''}
+                id={DEFAULT_FOCUS_ELEMENT_ID}
+                aria-describedby={QUESTION_DESCRIPTION_BUTTON_ID}
+              />
+            )}
+
+            {type === 'choices' && (
+              <ChoicesInput
+                question={question}
+                choices={choices}
+                value={String(value)}
+                setValue={(value) => {
+                  {
+                    setValue(value, { foldedStep: question })
+                  }
+                }}
+                isMissing={isMissing}
+                label={label || ''}
+                id={DEFAULT_FOCUS_ELEMENT_ID}
+                aria-describedby={QUESTION_DESCRIPTION_BUTTON_ID}
+              />
+            )}
+
+            {type === 'mosaic' && (
+              <Mosaic
+                question={question}
+                aria-describedby={QUESTION_DESCRIPTION_BUTTON_ID}
+              />
+            )}
+          </>
         )}
       </div>
 

--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -20,9 +20,10 @@ type Props = {
   question: string
   tempValue?: number | undefined
   setTempValue?: (value: number | undefined) => void
+  showInput?: boolean
 }
 
-export default function Question({ question, tempValue, setTempValue }: Props) {
+export default function Question({ question, tempValue, setTempValue, showInput = true }: Props) {
   const {
     type,
     label,
@@ -59,16 +60,19 @@ export default function Question({ question, tempValue, setTempValue }: Props) {
       <div className="mb-4">
         <Label question={question} label={label} description={description} />
 
-        <Suggestions
-          question={question}
-          setValue={(value) => {
-            if (type === 'number') {
-              if (setTempValue) setTempValue(value)
-            }
-            setValue(value, { foldedStep: question })
-          }}
-        />
-        {type === 'number' && (
+        {showInput && (
+          <Suggestions
+            question={question}
+            setValue={(value) => {
+              if (type === 'number') {
+                if (setTempValue) setTempValue(value)
+              }
+              setValue(value, { foldedStep: question })
+            }}
+          />
+        )}
+
+        {type === 'number' && showInput && (
           <NumberInput
             unit={unit}
             value={setTempValue ? tempValue : numericValue}
@@ -85,7 +89,7 @@ export default function Question({ question, tempValue, setTempValue }: Props) {
           />
         )}
 
-        {type === 'boolean' && (
+        {type === 'boolean' && showInput && (
           <BooleanInput
             value={value}
             setValue={(value) => {
@@ -100,7 +104,7 @@ export default function Question({ question, tempValue, setTempValue }: Props) {
           />
         )}
 
-        {type === 'choices' && (
+        {type === 'choices' && showInput && (
           <ChoicesInput
             question={question}
             choices={choices}
@@ -117,7 +121,7 @@ export default function Question({ question, tempValue, setTempValue }: Props) {
           />
         )}
 
-        {type === 'mosaic' && (
+        {type === 'mosaic' && showInput && (
           <Mosaic
             question={question}
             aria-describedby={QUESTION_DESCRIPTION_BUTTON_ID}

--- a/src/components/questions/Voiture.tsx
+++ b/src/components/questions/Voiture.tsx
@@ -1,39 +1,15 @@
 import Question from '@/components/form/Question'
-import Trans from '@/components/translation/Trans'
-import Button from '@/design-system/inputs/Button'
-import { useState } from 'react'
-import PencilIcon from '../icons/PencilIcon'
 import JourneysInput from './voiture/JourneysInput'
 
 type Props = {
   question: string
 }
 export default function Voiture({ question, ...props }: Props) {
-  const [isOpen, setIsOpen] = useState(false)
   return (
     <>
       <Question question={question} {...props} showInput={false} />
       <div className="mb-4 flex flex-col items-end">
-        <Button
-          color="link"
-          size="xs"
-          onClick={() => setIsOpen((prevIsOpen) => !prevIsOpen)}
-          className="mb-2">
-          {isOpen ? (
-            <Trans>Fermer</Trans>
-          ) : (
-            <span className="flex items-center">
-              <PencilIcon
-                className="mr-2 stroke-primary-700"
-                width="16"
-                height="16"
-              />
-
-              <Trans>Détailler mes trajets</Trans>
-            </span>
-          )}
-        </Button>
-        {isOpen ? <JourneysInput question={question} {...props} /> : null}
+        <JourneysInput question={question} {...props} />
       </div>
     </>
   )

--- a/src/components/questions/Voiture.tsx
+++ b/src/components/questions/Voiture.tsx
@@ -12,7 +12,7 @@ export default function Voiture({ question, ...props }: Props) {
   const [isOpen, setIsOpen] = useState(false)
   return (
     <>
-      <Question question={question} {...props} />
+      <Question question={question} {...props} showInput={false} />
       <div className="mb-4 flex flex-col items-end">
         <Button
           color="link"

--- a/src/components/questions/voiture/journeysInput/JourneysInputDesktop.tsx
+++ b/src/components/questions/voiture/journeysInput/JourneysInputDesktop.tsx
@@ -40,7 +40,7 @@ export function JourneysInputDesktop({
               <Trans>Fréquence</Trans>
             </th>
             <th className="table-cell p-2 text-left text-xs">
-              <Trans>Passagers</Trans>
+              <Trans>Nombre d’occupants (vous inclus)</Trans>
             </th>
             <th className="table-cell p-2 text-left text-xs opacity-0">
               Options

--- a/src/components/questions/voiture/journeysInput/journeysInputMobile/AddJourneyMobile.tsx
+++ b/src/components/questions/voiture/journeysInput/journeysInputMobile/AddJourneyMobile.tsx
@@ -91,7 +91,7 @@ export default function AddJourneyMobile({ setJourneys, className }: Props) {
           className="w-16 text-sm"
           name="passengers"
           value={passengers}
-          label={t('Passagers')}
+          label={t('Nombre d’occupants (vous inclus)')}
           onChange={(e) => setPassengers(Number(e.target.value))}>
           {new Array(5).fill(0).map((_, i) => {
             return (


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----
- Retrait du chiffre global et changement de wording. 
- Suppression de la fonctionnalité permettant d'afficher ou non le tableau de détails via un toggle.

:watermelon: Implémentation
----
- Ajout d'une propriété `showInput` dans `Question.tsx` pour contrôler l'affichage des suggestions et de l'input.
- Retrait du toggle d'affichage du tableau de détails.
- Ajustement du wording dans les différentes sections concernées.

:tada: Axes d'améliorations
----
- Optimiser la gestion conditionnelle de l'affichage des composants pour améliorer la performance.
- Ajouter des tests unitaires pour vérifier les conditions d'affichage des suggestions et de l'input.

:ballot_box_with_check: Checklist
----
- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)
