### PR TITLE
Ajout d'une réponse 'Je ne sais pas' 

### DIFF
--- a/src/components/form/Navigation.tsx
+++ b/src/components/form/Navigation.tsx
@@ -51,7 +51,7 @@ export default function Navigation({
       if (isMissing) {
         updateCurrentSimulation({
           situationToAdd: {
-            [question]: 'Je ne sais pas'
+            [question]: null
           },
           foldedStepToAdd: question
         })

--- a/src/components/form/Navigation.tsx
+++ b/src/components/form/Navigation.tsx
@@ -49,7 +49,12 @@ export default function Navigation({
       e.preventDefault()
 
       if (isMissing) {
-        updateCurrentSimulation({ foldedStepToAdd: question })
+        updateCurrentSimulation({
+          situationToAdd: {
+            [question]: 'Je ne sais pas'
+          },
+          foldedStepToAdd: question
+        })
       }
 
       handleMoveFocus()

--- a/src/pages/api/add-row.ts
+++ b/src/pages/api/add-row.ts
@@ -90,7 +90,13 @@ export default async function handler(
 function mapDataToSheet(simulationData: Record<string, any>, keys: string[]): any[][] {
   const values: any[] = [];
   keys.forEach(key => {
-    const value = simulationData.situation[key] || '';
+    let value = simulationData.situation[key];
+
+    if (value === null) {
+      value = 'je ne sais pas';
+    } else if (value === undefined) {
+      value = '';
+    }
     values.push(value);
   });
   return values;

--- a/src/pages/api/add-row.ts
+++ b/src/pages/api/add-row.ts
@@ -51,7 +51,7 @@ export default async function handler(
         type: 'service_account',
         project_id: process.env.GOOGLE_PROJECT_ID,
         private_key_id: process.env.GOOGLE_PRIVATE_KEY_ID,
-        private_key: process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+        private_key: Buffer.from(process.env.GOOGLE_PRIVATE_KEY, 'base64').toString('utf-8'),
         client_email: process.env.GOOGLE_CLIENT_EMAIL,
         client_id: process.env.GOOGLE_CLIENT_ID,
         auth_uri: process.env.GOOGLE_AUTH_URI,


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

- Tracer les réponses 'Je ne sais pas'

:watermelon: Implémentation
----

- Dans le code existant, la condition isMissing est utilisée pour vérifier si une entrée ou une réponse obligatoire est manquante avant de passer à l'étape suivante de la simulation.

- J'ai étendu cette logique pour inclure un nouveau cas : si l'utilisateur passe à la question suivante sans répondre, nous enregistrons automatiquement la réponse 'Je ne sais pas' pour la question en cours.

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)
