### PR TITLE
Ajout des informations d'aide à la saisie dans la feuille de calcul

### DIFF
--- a/src/app/_components/mainLayoutProviders/SimulationSyncProvider.tsx
+++ b/src/app/_components/mainLayoutProviders/SimulationSyncProvider.tsx
@@ -40,7 +40,8 @@ export default function SimulationSyncProvider({
     groups,
     savedViaEmail,
     opinionWayId,
-    voitures
+    voitures,
+    suggestions
   } = useCurrentSimulation()
 
   const { saveSimulation, isPending } = useSaveSimulation()
@@ -91,7 +92,8 @@ export default function SimulationSyncProvider({
           groups,
           savedViaEmail,
           opinionWayId,
-          voitures
+          voitures,
+          suggestions
         },
       })
     }, SAVE_DELAY)
@@ -112,7 +114,8 @@ export default function SimulationSyncProvider({
     shouldSyncWithBackend,
     resetSyncTimer,
     opinionWayId,
-    voitures
+    voitures,
+    suggestions
   ])
 
   useEffect(() => {

--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -63,10 +63,6 @@ export default function Question({ question, tempValue, setTempValue, showInput 
   ): void => {
     const suggestionKey = `${question} . aide saisie`;
 
-    if (currentSimulation.suggestions === undefined) {
-      currentSimulation.suggestions = {};
-    }
-
     currentSimulation.suggestions[suggestionKey] = value;
 
     currentSimulation.updateCurrentSimulation({ suggestions: currentSimulation.suggestions });

--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -59,7 +59,7 @@ export default function Question({ question, tempValue, setTempValue, showInput 
 
   const updateOrAddSuggestion = (
     question: string,
-    value: any
+    value: string | number
   ): void => {
     const suggestionKey = `${question} . aide saisie`;
 

--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -166,6 +166,7 @@ export default function Question({ question, tempValue, setTempValue, showInput 
           question={question}
           assistance={assistance}
           setTempValue={setTempValue}
+          updateOrAddSuggestion={updateOrAddSuggestion}
         />
       ) : null}
 

--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -15,7 +15,6 @@ import {
 import { useCurrentSimulation, useRule } from '@/publicodes-state'
 import { useEffect, useRef } from 'react'
 import Warning from './question/Warning'
-import { AideSaisie } from '@/publicodes-state/types'
 
 type Props = {
   question: string
@@ -63,16 +62,12 @@ export default function Question({ question, tempValue, setTempValue, showInput 
     value: any
   ): void => {
     const suggestionKey = `${question} . aide saisie`;
-    const existingSuggestion = currentSimulation.suggestions?.find(suggestion =>
-      Object.prototype.hasOwnProperty.call(suggestion, suggestionKey)
-    );
 
-    if (existingSuggestion) {
-      existingSuggestion[suggestionKey] = value;
-    } else {
-      const newSuggestion: AideSaisie = { [suggestionKey]: value };
-      currentSimulation.suggestions?.push(newSuggestion);
+    if (currentSimulation.suggestions === undefined) {
+      currentSimulation.suggestions = {};
     }
+
+    currentSimulation.suggestions[suggestionKey] = value;
 
     currentSimulation.updateCurrentSimulation({ suggestions: currentSimulation.suggestions });
   };

--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -15,6 +15,7 @@ import {
 import { useCurrentSimulation, useRule } from '@/publicodes-state'
 import { useEffect, useRef } from 'react'
 import Warning from './question/Warning'
+import {NodeValue} from "@/publicodes-state/types";
 
 type Props = {
   question: string
@@ -59,7 +60,7 @@ export default function Question({ question, tempValue, setTempValue, showInput 
 
   const updateOrAddSuggestion = (
     question: string,
-    value: string | number
+    value: NodeValue
   ): void => {
     const suggestionKey = `${question} . aide saisie`;
 

--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -12,9 +12,10 @@ import {
   DEFAULT_FOCUS_ELEMENT_ID,
   QUESTION_DESCRIPTION_BUTTON_ID,
 } from '@/constants/accessibility'
-import { useRule } from '@/publicodes-state'
+import { useCurrentSimulation, useRule } from '@/publicodes-state'
 import { useEffect, useRef } from 'react'
 import Warning from './question/Warning'
+import { AideSaisie } from '@/publicodes-state/types'
 
 type Props = {
   question: string
@@ -43,6 +44,8 @@ export default function Question({ question, tempValue, setTempValue, showInput 
   // It should happen only on mount (the component remount every time the question changes)
   const prevQuestion = useRef('')
 
+  const currentSimulation  = useCurrentSimulation()
+
   useEffect(() => {
     if (type !== 'number') {
       if (setTempValue) setTempValue(undefined)
@@ -54,6 +57,25 @@ export default function Question({ question, tempValue, setTempValue, showInput 
       prevQuestion.current = question
     }
   }, [type, numericValue, setTempValue, question])
+
+  const updateOrAddSuggestion = (
+    question: string,
+    value: any
+  ): void => {
+    const suggestionKey = `${question} . aide saisie`;
+    const existingSuggestion = currentSimulation.suggestions?.find(suggestion =>
+      Object.prototype.hasOwnProperty.call(suggestion, suggestionKey)
+    );
+
+    if (existingSuggestion) {
+      existingSuggestion[suggestionKey] = value;
+    } else {
+      const newSuggestion: AideSaisie = { [suggestionKey]: value };
+      currentSimulation.suggestions?.push(newSuggestion);
+    }
+
+    currentSimulation.updateCurrentSimulation({ suggestions: currentSimulation.suggestions });
+  };
 
   return (
     <>
@@ -69,6 +91,7 @@ export default function Question({ question, tempValue, setTempValue, showInput 
                   if (setTempValue) setTempValue(value)
                 }
                 setValue(value, { foldedStep: question })
+                updateOrAddSuggestion(question, value)
               }}
             />
 

--- a/src/components/form/question/Assistance.tsx
+++ b/src/components/form/question/Assistance.tsx
@@ -8,12 +8,14 @@ type Props = {
   question: string
   assistance: string
   setTempValue?: (value: number | undefined) => void
+  updateOrAddSuggestion: (question: string, value: any) => void
 }
 
 export default function Assistance({
                                      question,
                                      assistance,
                                      setTempValue,
+                                     updateOrAddSuggestion,
                                    }: Props) {
   const { setValue: setValueOfQuestion, value: valueOfQuestion } =
     useRule(question)
@@ -29,6 +31,14 @@ export default function Assistance({
   } = useRule(assistance)
 
   const { numericValue: numericValueOfParent } = useRule(parent)
+
+  const handleSetValueOfAssistance = (value: number | undefined) => {
+    setValueOfAssistance(value); // Mettre à jour la valeur de l'assistance
+    if (setTempValue) {
+      setTempValue(value); // Mettre à jour la valeur temporaire
+    }
+    updateOrAddSuggestion(question, value);
+  };
 
   // If the assistance value changed and it is not synced with the question value
   // we update the question value (and the tempValue of the input)
@@ -66,7 +76,7 @@ export default function Assistance({
         <NumberInput
           unit={unit ? unit.split('/')[0] : ''}
           value={numericValueOfAssistance}
-          setValue={setValueOfAssistance}
+          setValue={handleSetValueOfAssistance}
           isMissing={numericValueOfAssistance ? false : true}
         />
       )}

--- a/src/data/keys.json
+++ b/src/data/keys.json
@@ -179,5 +179,6 @@
   "logement . chauffage . bois . type . bûches . consommation",
   "transport . ferry . heures",
   "transport . vacances . camping car . km",
-  "transport . vacances . camping car . consommation aux 100"
+  "transport . vacances . camping car . consommation aux 100",
+  "logement . électricité . réseau . consommation . aide saisie"
 ]

--- a/src/helpers/simulation/generateSimulation.ts
+++ b/src/helpers/simulation/generateSimulation.ts
@@ -17,7 +17,8 @@ export function generateSimulation({
   savedViaEmail,
   migrationInstructions,
   opinionWayId,
-  voitures = []
+  voitures = [],
+  suggestions = []
 }: Partial<Simulation> & {
   migrationInstructions?: MigrationType
 } = {}): Simulation {
@@ -35,7 +36,8 @@ export function generateSimulation({
     groups,
     savedViaEmail,
     opinionWayId,
-    voitures
+    voitures,
+    suggestions
   } as Simulation
 
   if (migrationInstructions) {

--- a/src/helpers/simulation/generateSimulation.ts
+++ b/src/helpers/simulation/generateSimulation.ts
@@ -18,7 +18,7 @@ export function generateSimulation({
   migrationInstructions,
   opinionWayId,
   voitures = [],
-  suggestions = []
+  suggestions = {}
 }: Partial<Simulation> & {
   migrationInstructions?: MigrationType
 } = {}): Simulation {

--- a/src/pages/api/add-row.ts
+++ b/src/pages/api/add-row.ts
@@ -76,7 +76,7 @@ export default async function handler(
     };
 
     const values = [mapDataToSheet(fusion, keys)];
-    values[0][0].unshift(userId); // Insert userId at the beginning
+    values[0][0] = userId
 
     const resource = { values };
 

--- a/src/pages/api/add-row.ts
+++ b/src/pages/api/add-row.ts
@@ -76,7 +76,7 @@ export default async function handler(
     };
 
     const values = [mapDataToSheet(fusion, keys)];
-    values[0].unshift(userId); // Insert userId at the beginning
+    values[0][0].unshift(userId); // Insert userId at the beginning
 
     const resource = { values };
 

--- a/src/pages/api/add-row.ts
+++ b/src/pages/api/add-row.ts
@@ -31,6 +31,7 @@ export default async function handler(
 
   try {
     const data = req.body.data;
+
     if (!data) {
       return res.status(400).json({ message: ERROR_MESSAGES.INVALID_UUID });
     }
@@ -64,9 +65,17 @@ export default async function handler(
       scopes: ['https://www.googleapis.com/auth/spreadsheets'],
     });
 
+
+
     const service = google.sheets({ version: 'v4', auth });
 
-    const values = [mapDataToSheet(jsonData.simulation, keys)];
+
+    const fusion = {
+      ...jsonData.simulation.situation,
+      ...jsonData.simulation.suggestions,
+    };
+
+    const values = [mapDataToSheet(fusion, keys)];
     values[0].unshift(userId); // Insert userId at the beginning
 
     const resource = { values };
@@ -120,7 +129,7 @@ export default async function handler(
 function mapDataToSheet(simulationData: Record<string, any>, keys: string[]): any[][] {
   const values: any[] = [];
   keys.forEach(key => {
-    let value = simulationData.situation[key];
+    let value = simulationData[key];
 
     if (value === null) {
       value = 'je ne sais pas';

--- a/src/publicodes-state/types.d.ts
+++ b/src/publicodes-state/types.d.ts
@@ -76,7 +76,7 @@ export type Simulation = {
   savedViaEmail?: boolean
   opinionWayId: string
   voitures?: Journey[]
-  suggestions?: AideSaisie[]
+  suggestions?: AideSaisie
 }
 
 type UpdateCurrentSimulationProps = {
@@ -93,7 +93,7 @@ type UpdateCurrentSimulationProps = {
   groupToDelete?: string | null
   savedViaEmail?: boolean
   voitures?: Journey[]
-  suggestions?: AideSaisie[]
+  suggestions?: AideSaisie
 }
 
 export type Persona = {

--- a/src/publicodes-state/types.d.ts
+++ b/src/publicodes-state/types.d.ts
@@ -76,7 +76,7 @@ export type Simulation = {
   savedViaEmail?: boolean
   opinionWayId: string
   voitures?: Journey[]
-  suggestions?: AideSaisie
+  suggestions: AideSaisie
 }
 
 type UpdateCurrentSimulationProps = {

--- a/src/publicodes-state/types.d.ts
+++ b/src/publicodes-state/types.d.ts
@@ -32,6 +32,8 @@ export type Tutorials = Record<string, boolean>
 
 export type Situation = Record<DottedName, NodeValue>
 
+export type AideSaisie = Record<DottedName, NodeValue>
+
 export type Suggestion = {
   label: string
   value: any // TODO: sorry...
@@ -74,6 +76,7 @@ export type Simulation = {
   savedViaEmail?: boolean
   opinionWayId: string
   voitures?: Journey[]
+  suggestions?: AideSaisie[]
 }
 
 type UpdateCurrentSimulationProps = {
@@ -90,6 +93,7 @@ type UpdateCurrentSimulationProps = {
   groupToDelete?: string | null
   savedViaEmail?: boolean
   voitures?: Journey[]
+  suggestions?: AideSaisie[]
 }
 
 export type Persona = {


### PR DESCRIPTION
:triangular_flag_on_post: **Objectifs**  
----  
Implémenter la sauvegarde des aides pour les champs de texte et de nombre dans le localStorage, gérer correctement la sauvegarde des situations identiques, et fusionner les suggestions avec les situations avant de les ajouter dans le tableur.

:watermelon: **Implémentation**  
----  
- Ajout de la fonctionnalité de sauvegarde des aides pour les champs de texte et de nombre dans le localStorage.
- Gestion de la sauvegarde des situations identiques dans le localStorage pour éviter les duplications.
- Fusion des suggestions avec les situations, puis ajout dans un fichier de tableur pour une meilleure organisation.

:tada: **Axes d'améliorations**  
----  

:ballot_box_with_check: **Checklist**  
----  
- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)  
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop  
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)  
