### PR TITLE
Multiple fixes

### DIFF
--- a/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/simulateur/Form.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/simulateur/Form.tsx
@@ -10,6 +10,7 @@ import { useContext, useEffect, useMemo, useState } from 'react'
 import ColorIndicator from './form/ColorIndicator'
 import TransitionPage from '@/app/(layout-with-navigation)/(simulation)/transition/page'
 import { TransitionPageKey, transitions } from '@/constants/transitions'
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 
 export default function Form() {
   const isDebug = useDebug()
@@ -18,8 +19,10 @@ export default function Form() {
 
   const {
     transitionPage,
+    setTransitionPage,
     remainingQuestions,
     relevantAnsweredQuestions,
+    relevantQuestions,
     currentQuestion,
     setCurrentQuestion,
     noPrevQuestion,
@@ -60,24 +63,21 @@ export default function Form() {
 
   useEffect(() => {
     if (!isInitialized) {
+      let nextCurrentQuestion;
       if (
         questionInQueryParams &&
         (relevantAnsweredQuestions.includes(questionInQueryParams) || isDebug)
       ) {
-        setCurrentQuestion(questionInQueryParams)
+        nextCurrentQuestion = questionInQueryParams;
       } else {
-        setCurrentQuestion(remainingQuestions[0])
+        nextCurrentQuestion = remainingQuestions[0];
       }
+      if (relevantQuestions?.indexOf(nextCurrentQuestion) === 0) setTransitionPage(getNamespace(relevantQuestions[0]))
+      setCurrentQuestion(nextCurrentQuestion);
+
       setIsInitialized(true)
     }
-  }, [
-    isDebug,
-    questionInQueryParams,
-    remainingQuestions,
-    relevantAnsweredQuestions,
-    setCurrentQuestion,
-    isInitialized,
-  ])
+  }, [isDebug, questionInQueryParams, remainingQuestions, relevantAnsweredQuestions, setCurrentQuestion, isInitialized, relevantQuestions, setTransitionPage])
 
   useEffect(() => {
     window.scrollTo(0, 0)

--- a/src/app/_components/heading/Buttons.tsx
+++ b/src/app/_components/heading/Buttons.tsx
@@ -4,13 +4,10 @@ import Trans from '@/components/translation/Trans'
 import ButtonLink from '@/design-system/inputs/ButtonLink'
 import { useSimulateurPage } from '@/hooks/navigation/useSimulateurPage'
 import { useIsClient } from '@/hooks/useIsClient'
-import { useCurrentSimulation } from '@/publicodes-state'
 import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 export default function Buttons() {
-  const { progression } = useCurrentSimulation()
-
   const isClient = useIsClient()
 
   const {
@@ -28,12 +25,7 @@ export default function Buttons() {
         }`}
         href={getLinkToSimulateurPage()}
         onMouseEnter={() => setIsHover(true)}
-        onMouseLeave={() => setIsHover(false)}
-        onClick={() => {
-          if (progression > 0) {
-            return
-          }
-        }}>
+        onMouseLeave={() => setIsHover(false)}>
         <span
           className={twMerge(
             isHover

--- a/src/components/form/Navigation.tsx
+++ b/src/components/form/Navigation.tsx
@@ -71,12 +71,6 @@ export default function Navigation({
       else if (value === 'non') {
         value = 'FALSE'
       }
-      // Gestion du cas undefined
-      // par exemple pour logement . vacances . camping . nombre de nuitées qui prenait la valeur par défaut
-      // alors que la question n'était pas dans le sondage
-      else if (value === undefined) {
-        value = ''
-      }
       else if (!key.includes('aide saisie')) {
         value = safeEvaluateHelper(key, engine)?.nodeValue ?? '';
       }

--- a/src/components/form/Navigation.tsx
+++ b/src/components/form/Navigation.tsx
@@ -10,7 +10,7 @@ import { useMagicKey } from '@/hooks/useMagicKey'
 import { useCurrentSimulation, useEngine, useRule } from '@/publicodes-state'
 import { DottedName } from '@/publicodes-state/types'
 
-import { MouseEvent, useCallback, useState } from 'react'
+import { MouseEvent, useCallback, useMemo, useState } from 'react'
 import { safeEvaluateHelper } from '@/publicodes-state/helpers/safeEvaluateHelper'
 
 type Props = {
@@ -44,10 +44,13 @@ export default function Navigation({
 
   const { updateCurrentSimulation } = useCurrentSimulation()
 
-  const isNextDisabled =
-      (tempValue !== undefined && plancher !== undefined && tempValue < plancher) || value === undefined
+  const isNextDisabled = useMemo(() => {
+    return !transitionPage &&
+    ((tempValue !== undefined && plancher !== undefined && tempValue < plancher) || value === undefined);
+  }, [plancher, tempValue, transitionPage, value]);
 
   const [_data, setData] = useState(null);
+
   // Fonction pour préparer les données à envoyer
   const prepareDataToSend = useCallback((JSONValue: any, headers: any[]): Record<string, any>[] => {
     const dataToSend: any[] = [];

--- a/src/components/questions/Avion.tsx
+++ b/src/components/questions/Avion.tsx
@@ -1,35 +1,12 @@
 import Question from '@/components/form/Question'
-import Trans from '@/components/translation/Trans'
-import Button from '@/design-system/inputs/Button'
-import { useState } from 'react'
-import PencilIcon from '../icons/PencilIcon'
-import ThreeYearsInput from './avion/ThreeYearsInput'
 
 type Props = {
   question: string
 }
 export default function Avion({ question, ...props }: Props) {
-  const [isOpen, setIsOpen] = useState(false)
   return (
     <>
       <Question question={question} {...props} />
-      <div className="mb-4 flex flex-col items-end">
-        <Button
-          color="link"
-          size="xs"
-          onClick={() => setIsOpen((prevIsOpen) => !prevIsOpen)}
-          className="mb-2">
-          {isOpen ? (
-            <Trans>Fermer</Trans>
-          ) : (
-            <>
-              <PencilIcon className="mr-2 stroke-primary-700" width="16" />
-              <Trans>Répondre sur les 3 dernières années</Trans>
-            </>
-          )}
-        </Button>
-        {isOpen ? <ThreeYearsInput question={question} {...props} /> : null}
-      </div>
     </>
   )
 }

--- a/src/components/questions/plats/DishesNumberInfo.tsx
+++ b/src/components/questions/plats/DishesNumberInfo.tsx
@@ -1,5 +1,4 @@
 import Trans from '@/components/translation/Trans'
-import Emoji from '@/design-system/utils/Emoji'
 import { useRule } from '@/publicodes-state'
 
 export default function DishesNumberInfo() {
@@ -10,32 +9,14 @@ export default function DishesNumberInfo() {
   return (
     <>
       <div aria-live="polite" className="mb-2 text-center text-sm">
-        {totalNumberOfPlats < 12 ? (
+        {totalNumberOfPlats < 14 ? (
           <span className="text-red-700">
-            <strong>{totalNumberOfPlats}</strong>{' '}
-            <strong>
-              <Trans>repas</Trans>
-            </strong>{' '}
-            <Trans>par semaine, quel appétit de moineau</Trans>
-            <Emoji>🐦</Emoji>
+            <Trans>Êtes-vous sûr de faire moins de 14 repas ?</Trans>
           </span>
         ) : null}
-        {totalNumberOfPlats > 16 ? (
+        {totalNumberOfPlats > 14 ? (
           <span className="text-red-700">
-            <strong>{totalNumberOfPlats}</strong>{' '}
-            <strong>
-              <Trans>repas</Trans>
-            </strong>{' '}
-            <Trans>par semaine, quel appétit !</Trans> <Emoji>💪</Emoji>
-          </span>
-        ) : null}
-        {totalNumberOfPlats >= 12 && totalNumberOfPlats <= 16 ? (
-          <span>
-            <strong>{totalNumberOfPlats}</strong>{' '}
-            <strong>
-              <Trans>repas</Trans>
-            </strong>{' '}
-            <Trans>par semaine, miam</Trans> <Emoji>😋</Emoji>
+            <Trans>Êtes-vous sûr de faire plus de 14 repas ?</Trans>
           </span>
         ) : null}
       </div>

--- a/src/publicodes-state/hooks/useForm/index.ts
+++ b/src/publicodes-state/hooks/useForm/index.ts
@@ -21,6 +21,7 @@ export default function useForm() {
 
   const {
     transitionPage,
+    setTransitionPage,
     gotoPrevQuestion,
     gotoNextQuestion,
     noPrevQuestion,
@@ -39,6 +40,7 @@ export default function useForm() {
      * Undefined unless when a transitionPage needs to be displayed (between categories)
      */
     transitionPage,
+    setTransitionPage,
     /**
      * Every questions (answered and missing) that should be displayed in the form
      */

--- a/src/publicodes-state/hooks/useForm/useNavigation.ts
+++ b/src/publicodes-state/hooks/useForm/useNavigation.ts
@@ -26,8 +26,8 @@ export default function useNavigation({
   )
 
   const noPrevQuestion = useMemo<boolean>(
-    () => currentQuestionIndex === 0 && !transitionPage,
-    [currentQuestionIndex, transitionPage]
+    () => transitionPage === getNamespace(relevantQuestions[0]),
+    [relevantQuestions, transitionPage]
   )
   const noNextQuestion = useMemo<boolean>(
     () => !relevantQuestions[currentQuestionIndex + 1],
@@ -98,6 +98,7 @@ export default function useNavigation({
 
   return {
     transitionPage,
+    setTransitionPage,
     gotoPrevQuestion,
     gotoNextQuestion,
     noPrevQuestion,

--- a/src/publicodes-state/hooks/useRule/useContent.ts
+++ b/src/publicodes-state/hooks/useRule/useContent.ts
@@ -26,7 +26,9 @@ export default function useContent({ dottedName, rule }: Props) {
     [rule]
   )
   const description = useMemo<string | undefined>(
-    () => rule?.rawNode.description,
+    () => {
+      return rule?.rawNode.description?.replace(/^\n.*Cette règle provient du modèle.*\n\n\n/i, "")
+    },
     [rule]
   )
   const icons = useMemo<string | undefined>(

--- a/src/publicodes-state/hooks/useRule/useQuestionsOfMosaic.ts
+++ b/src/publicodes-state/hooks/useRule/useQuestionsOfMosaic.ts
@@ -22,9 +22,10 @@ export default function useQuestionsOfMosaic({
     () => {
       if (options?.length) {
         return options.map(
-          (mosaicName) =>
+          (mosaicName) => {
             // TODO: we should manage the case where options don't correspond to exisiting rules
-             everyMosaicChildren.find((child) => child.endsWith(mosaicName)) ?? ''
+            return everyMosaicChildren.find((child) => child.match(new RegExp(`\\b${mosaicName}$`))) ?? ''
+          }
         ) ?? [];
       }
 
@@ -32,11 +33,11 @@ export default function useQuestionsOfMosaic({
         (mosaicName) => {
           const tmpMosaicName = mosaicName.replace(" . choix . nombre", "");
           // TODO: we should manage the case where options don't correspond to exisiting rules
-          const mosaicParent = everyRules.find((child) => child.endsWith(`${tmpMosaicName} . nombre`)) ?? ''
+          const mosaicParent = everyRules.find((child) => child.match(new RegExp(`\\b${tmpMosaicName}$`))) ?? ''
           if (!mosaicParent) return '';
 
           const parentValue = engine.evaluate(mosaicParent);
-          if (parentValue.nodeValue > 0) return everyMosaicChildren.find((child) => child.endsWith(mosaicName)) ?? ''
+          if (parentValue.nodeValue > 0) return everyMosaicChildren.find((child) => child.match(new RegExp(`\\b${mosaicName}$`))) ?? ''
 
           return ''
         }

--- a/src/publicodes-state/providers/simulationProvider/useRules.ts
+++ b/src/publicodes-state/providers/simulationProvider/useRules.ts
@@ -60,12 +60,12 @@ export function useRules({ engine, root }: Props) {
         }
         const mosaicChildren = mosaicRule.rawNode.mosaique['options']?.map(
           (option: string) => {
-            return everyQuestions.find((rule) => rule.endsWith(option)) || ''
+            return everyQuestions.find((rule) => rule.match(new RegExp(`\\b${option}$`))) || ''
           }
         ) ?? [];
         const mosaicSiChildren = mosaicRule.rawNode.mosaique['optionsConditionnelles']?.map(
           (option: string) => {
-            return everyQuestions.find((rule) => rule.endsWith(option)) || ''
+            return everyQuestions.find((rule) => rule.match(new RegExp(`\\b${option}$`))) || ''
           }
         ) ?? [];
 


### PR DESCRIPTION
- Afficher la page de transition comme première page
- Changements de certains texte
- Fix du problème des variables qui ne s'enregistre pas dans l'excel
- fix du bouton suivant qui n'était pas toujours désactivé au bon moment 
- suppression de la partie pour répondre sur 3 ans à lavion
- suppression de l'info qu'une question vient d'un autre modèle
- réparation des mosaic dans les cas où les noms des options ont des parties en commun (ex: ordinateur portable et table)